### PR TITLE
Modifier le type des champs HTML, CSS et JavaScript afin de permettre la saisie en texte multiligne

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "injecteur-code-personnalise",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Injecteur de code personnalisé (HTML, CSS, JavaScript) pour Budibase - Affichage texte corrigé",
   "author": "MEMORA Solutions - Stéphane Lapointe <stephane@memora.ca> (https://memora.solutions)",
   "contributors": [

--- a/schema.json
+++ b/schema.json
@@ -51,7 +51,11 @@
         "key": "intervalTime",
         "defaultValue": 1000,
         "min": 100,
-        "max": 60000
+        "max": 60000,
+        "dependsOn": {
+          "setting": "executionMode",
+          "value": "onInterval"
+        }
       },
       {
         "type": "boolean",

--- a/schema.json
+++ b/schema.json
@@ -8,19 +8,19 @@
     "icon": "Code",
     "settings": [
       {
-        "type": "text",
+        "type": "text/multiline",
         "label": "Code HTML",
         "key": "htmlCode",
         "defaultValue": ""
       },
       {
-        "type": "text",
+        "type": "text/multiline",
         "label": "Code CSS",
         "key": "cssCode",
         "defaultValue": ""
       },
       {
-        "type": "text",
+        "type": "text/multiline",
         "label": "Code JavaScript",
         "key": "jsCode",
         "defaultValue": ""
@@ -51,10 +51,7 @@
         "key": "intervalTime",
         "defaultValue": 1000,
         "min": 100,
-        "max": 60000,
-        "showIf": {
-          "executionMode": "onInterval"
-        }
+        "max": 60000
       },
       {
         "type": "boolean",

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -39,7 +39,7 @@
       } else {
         eval(jsCode)
       }
-      notificationStore?.actions?.success("Code JavaScript exécuté avec succès")
+      //notificationStore?.actions?.success("Code JavaScript exécuté avec succès")
     } catch (error) {
       console.error("Erreur d'exécution JavaScript:", error)
       notificationStore?.actions?.error(`Erreur JavaScript: ${error.message}`)


### PR DESCRIPTION
Permet d’insérer des sauts de ligne sans avoir à ouvrir l’éditeur complet. Évite également d’écraser involontairement les sauts de ligne en cliquant dans le champ.

Changer showIf pour dependsOn dans la clé intervalTime.